### PR TITLE
Add volume and move grav installation in entrypoint.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,40 @@
+image: docker:latest
+
+services:
+  - docker:dind
+
+before_script:
+  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+
+build-master:
+  stage: build
+  script:
+    - docker pull "$CI_REGISTRY_IMAGE:latest" || true
+    - docker build --cache-from "$CI_REGISTRY_IMAGE:latest" --pull -t "$CI_REGISTRY_IMAGE:latest" .
+    - docker push "$CI_REGISTRY_IMAGE:latest"
+  only:
+    - master
+    - schedules
+
+build-master-tag:
+  stage: build
+  script:
+    - docker build --pull -t $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+  only:
+    - tags
+    - schedules
+    - master
+  except:
+    - branches
+
+build:
+  stage: build
+  script:
+    - docker pull "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" || true
+    - docker build --cache-from "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - master
+  only:
+    - branches

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@ FROM php:7.2-apache
 LABEL maintainer="Andy Miller <rhuk@getgrav.org> (@rhukster)" \
       maintainer="Romain Fluttaz <romain@fluttaz.fr>"
 
+# install dependencies we need
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
+        unzip
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN set -ex; \
 	\
     pecl install apcu; \
     pecl install yaml; \
+	docker-php-ext-install apcu yaml; \
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/; \
-	docker-php-ext-install gd mysqli opcache zip ldap apcu yaml; \
+	docker-php-ext-install gd mysqli opcache zip ldap; \
 	\
     # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex; \
 	\
     pecl install apcu; \
     pecl install yaml; \
-	docker-php-ext-install apcu yaml; \
+	docker-php-ext-enable apcu yaml; \
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	docker-php-ext-install gd mysqli opcache zip ldap; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:7.2-apache
+ARG PHP_VERSION=7.2
+
+FROM php:${PHP_VERSION}-apache
 LABEL maintainer="Andy Miller <rhuk@getgrav.org> (@rhukster)" \
       maintainer="Romain Fluttaz <romain@fluttaz.fr>"
 
@@ -16,7 +18,6 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-        unzip \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
@@ -48,42 +49,46 @@ RUN set -ex; \
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=2'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-		echo 'upload_max_filesize=128M'; \
-		echo 'post_max_size=128M'; \
-	} > /usr/local/etc/php/conf.d/php-recommended.ini
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+RUN { \
+        echo 'upload_max_filesize = 128M'; \
+        echo 'post_max_size = 128M'; \
+        echo 'max_execution_time = 600'; \
+        echo 'max_input_vars = 5000'; \
+    } > /usr/local/etc/php/conf.d/php-optimisations.ini
+
 
 # Enable Apache Rewrite + Expires Module
 RUN a2enmod rewrite expires
 
-# VOLUME /var/www/html
+VOLUME /var/www/html
 
-# Set user to www-data
-RUN chown www-data:www-data /var/www
-USER www-data
+RUN chown -R www-data:www-data /var/www
 
 # Define Grav version and expected SHA1 signature
 ENV GRAV_VERSION 1.5.1
 ENV GRAV_SHA1 5292b05d304329beefeddffbf9f542916012c221
 
 # Install grav
-WORKDIR /var/www
-RUN curl -o grav-admin.zip -SL https://getgrav.org/download/core/grav-admin/${GRAV_VERSION} && \
-    echo "$GRAV_SHA1 grav-admin.zip" | sha1sum -c - && \
-    unzip grav-admin.zip && \
-    mv -T /var/www/grav-admin /var/www/html && \
-    rm grav-admin.zip
+RUN set -ex; \
+    curl -o grav-admin.zip -fSL https://getgrav.org/download/core/grav-admin/${GRAV_VERSION}; \
+    echo "$GRAV_SHA1 grav-admin.zip" | sha1sum -c -; \
+    # upstream tarballs include ./grav-admin/ so this gives us /usr/src/grav-admin
+    unzip grav-admin.zip -d /usr/src/; \
+    rm grav-admin.zip; \
+    chown -R www-data:www-data /usr/src/grav-admin
 
 # Return to root user
 USER root
 
-# Copy init scripts
-# COPY docker-entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/
 
-# ENTRYPOINT ["/entrypoint.sh"]
-# CMD ["apache2-foreground"]
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["apache2-foreground"]"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,8 @@ VOLUME /var/www/html
 RUN chown -R www-data:www-data /var/www
 
 # Define Grav version and expected SHA1 signature
-ENV GRAV_VERSION 1.5.1
-ENV GRAV_SHA1 5292b05d304329beefeddffbf9f542916012c221
+ENV GRAV_VERSION 1.5.3
+ENV GRAV_SHA1 2265fd3624278922c009ca2907977d1ccc7a8253
 
 # Install grav
 RUN set -ex; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Official Docker Image for Grav
+# Docker Image for Grav
 
-This currently is pretty minimal and uses:
+_[Based on official grav docker image](https://github.com/getgrav/docker-grav)_
+
+Fonctionnalities :
 
 * apache-2.4.8
 * GD library
@@ -9,6 +11,7 @@ This currently is pretty minimal and uses:
 * php7.2-opcache
 * php7.2-acpu
 * php7.2-yaml
+* php7.2-ldap
 
 ## Building the image from Dockerfile
 
@@ -24,18 +27,4 @@ docker run -p 8000:80 grav:latest
 
 Point browser to `http://localhost/8000` and create user account...
 
-## Running local Grav installation
 
-This assumes you have already downloaded a Grav package into a local folder. This is the best way to run Grav if you want to have your changes persisted between restarts of the docker container.
-
-```
-docker run -v /local/grav/install:/var/www/html:cached -p 8000:80/tcp grav:latest
-```
-
-To run in the current directory you can use:
-
-```
-docker run -v `pwd`:/var/www/html:cached -p 8000:80/tcp grav:latest
-```
-
-Point browser to `http://localhost/8000` to access your Grav site

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 _[Based on official grav docker image](https://github.com/getgrav/docker-grav)_
 
+**Grav version : 1.5.3**
+
 Fonctionnalities :
 
-* apache-2.4.8
-* GD library
-* Unzip library
-* php7.2
-* php7.2-opcache
-* php7.2-acpu
-* php7.2-yaml
-* php7.2-ldap
+  * apache-2.4.8
+  * GD library
+  * Unzip library
+  * php7.2
+  * php7.2-opcache
+  * php7.2-acpu
+  * php7.2-yaml
+  * php7.2-ldap
 
 ## Building the image from Dockerfile
 
@@ -19,12 +21,62 @@ Fonctionnalities :
 docker build -t grav:latest .
 ```
 
-## Running Grav Image with Latest Grav + Admin (not persistent):
+## Running
 
-```
-docker run -p 8000:80 grav:latest
-```
+You can find 2 version of this image, one on [gitlab botux-fr/docker/grav](https://gitlab.com/botux-fr/docker/grav) _with the CI tools_, the other on docker-hub, link to the [github repository boTux-fr/docker-grav](https://github.com/boTux-fr/docker-grav).
+
+  * Latest botux-grav image on gitlab : [Grav images @ gitlab](https://gitlab.com/botux-fr/docker/grav/container_registry).
+  * Other version on hub.docker : [Grav images @ docker hub](https://hub.docker.com/r/botux/grav/)
+
+### Running Grav Image with Latest Grav + Admin (not persistent):
+
+    docker run -p 8000:80 registry.gitlab.com/botux-fr/docker/grav:latest
 
 Point browser to `http://localhost/8000` and create user account...
 
+### With docker-compose : 
 
+```yaml
+version: "3.6"
+
+services:
+  grav:
+    image: registry.gitlab.com/botux-fr/docker/grav:latest
+    restart: always
+    ports:
+      - 8080:80
+    volumes:
+      - ./data/:/var/www/html/
+```
+_And go on http://localhost:8080/_
+
+--------------------
+#### docker-compose and a reverse proxy like traefik
+
+If you're using traefik as reverse proxy, you can use : 
+
+```yaml
+version: "3.6"
+
+networks:
+  reverse-proxy:
+    name: reverse-proxy
+    external: true
+
+services:
+  grav:
+    image: registry.gitlab.com/botux-fr/docker/grav:latest
+    restart: always
+    networks:
+      - reverse-proxy
+    labels:
+      - "traefik.docker.network=reverse-proxy"
+      - "traefik.enable=true"
+      - "traefik.port=80"
+      - "traefik.backend=grav"
+      - "traefik.frontend.passHostHeader=true"
+      - "traefik.frontend.rule=Host:${DOMAIN:-my.domain.tld}"
+      - "traefik.frontend.whiteList.sourceRange=${WHITELIST:-}"
+    volumes:
+      - ./data/:/var/www/html/
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if [ "$(id -u)" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-www-data}"
+				group="${APACHE_RUN_GROUP:-www-data}"
+				;;
+			*) # php-fpm
+				user='www-data'
+				group='www-data'
+				;;
+		esac
+	else
+		user="$(id -u)"
+		group="$(id -g)"
+	fi
+
+	if [ ! -e index.php ]; then
+		echo >&2 "Grav not found in $PWD - copying now..."
+		if [ "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+			( set -x; ls -A; sleep 10 )
+		fi
+		tar --create \
+			--file - \
+			--one-file-system \
+			--directory /usr/src/grav-admin \
+			--owner "$user" --group "$group" \
+			. | tar --extract --file -
+		echo >&2 "Complete! Grav has been successfully copied to $PWD"
+	fi
+fi
+exec "$@"
+


### PR DESCRIPTION
With the new [entrypoint.sh](entrypoint.sh) and the edition in the [Dockerfile](Dockerfile), grav is now downloaded and extracted to `/usr/src/` and the at first start it's copied in `/var/www/html` if index.php doesn't exist.

Heavily based on wordpress image.

I also added ldap php dependencies. _Should we add also other deps like redis ?_