### PR TITLE
added a few extenstions for PHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@ RUN apt-get update && apt-get install -y \
         libjpeg62-turbo-dev \
         libpng-dev \
         libyaml-dev \
+	zlib1g-dev \
+	libicu-dev \
+	g++ \
+	git \
     && docker-php-ext-install opcache \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install zip
@@ -27,6 +33,7 @@ RUN { \
 		echo 'opcache.enable_cli=1'; \
 		echo 'upload_max_filesize=128M'; \
 		echo 'post_max_size=128M'; \
+		echo 'extension=intl.so'; \
 	} > /usr/local/etc/php/conf.d/php-recommended.ini
 
  # provide container inside image for data persistance


### PR DESCRIPTION
considering that Grav can be used internationally, i've added the `intl` extension and it's auto configuration. 
also i've enabled the `intl` extenstion

- at least that is what i believe i did considering https://github.com/docker-library/php/issues/57#issuecomment-238077158