### PR TITLE
Change variable type of GRAV_VERSION from ENV to ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chown www-data:www-data /var/www
 USER www-data
 
 # Define Grav specific version of Grav or use latest stable
-ENV GRAV_VERSION latest
+ARG GRAV_VERSION=latest
 
 # Install grav
 WORKDIR /var/www


### PR DESCRIPTION
Changes the variable of ``GRAV_VERSION`` to ``ARG`` to make sure you can set the desired image version with environment variables when building the docker image.

Fixes #39 