### PR TITLE
fix(volume): restrict persisting to user data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ USER root
 # COPY docker-entrypoint.sh /entrypoint.sh
 
 # provide container inside image for data persistence
-VOLUME ["/var/www/html"]
+VOLUME ["/var/www/html/backup", "/var/www/html/logs", "/var/www/html/user"]
 
 # ENTRYPOINT ["/entrypoint.sh"]
 # CMD ["apache2-foreground"]


### PR DESCRIPTION
This enables updating Grav via Docker, as the Grav code is not persisted in a volume anymore.