### PR TITLE
Populate user dir once (#44)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,9 @@ USER root
 RUN { \
     echo '#!/bin/bash'; \
     echo '# Ensure user dir exists'; \
-    echo 'sudo -iu www-data mkdir -p /var/www/html/user/'; \
+    echo 'mkdir -p /var/www/html/user/'; \
+    echo '# Ensure user dir is owned by user www-data'; \
+    echo 'chown www-data: /var/www/html/user/'; \
     echo '# Populate user dir if it is empty'; \
     echo 'if test -n "$(find /var/www/html/user -maxdepth 0 -empty)" ; then'; \
     echo 'cp -rp /var/www/grav-admin/user/* /var/www/html/user/'; \

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ This currently is pretty minimal and uses:
 
 ## Persisting data
 
-To save the Grav site data to the host file system (so that it persists even after the container has been removed), simply map the container's `/var/www/html` directory to a named Docker volume or to a directory on the host.
+To save the Grav site data to the host file system (so that it persists even after the container has been removed), simply map the container's `/var/www/html/user` directory to a named Docker volume or to a directory on the host.
 
-> If the mapped directory or named volume is empty, it will be automatically populated with a fresh install of Grav the first time that the container starts. However, once the directory/volume has been populated, the data will persist and will not be overwritten the next time the container starts.
+> If the mapped directory or named volume is empty, it will be automatically populated with a fresh user dir the first time that the container starts. However, once the directory/volume has been populated, the data will persist and will not be overwritten the next time the container starts.
+
+This also applies for '/var/www/backup' and '/var/www/logs' except population at first startup.
 
 ## Building the image from Dockerfile
 
@@ -35,7 +37,7 @@ Point browser to `http://localhost:8000` and create user account...
 ## Running Grav Image with Latest Grav + Admin with a named volume (can be used in production)
 
 ```
-docker run -d -p 8000:80 --restart always -v grav_data:/var/www/html grav:latest
+docker run -d -p 8000:80 --restart always -v grav_backup:/var/www/backup -v grav_logs:/var/www/logs -v gravi_user:/var/www/html/user grav:latest
 ```
 
 ## Running Grav Image with docker-compose and a volume mapped to a local directory


### PR DESCRIPTION
I found another way to install grav by populating user dir if empty during container start. Therefore i skip user dir during build. A script will then populate /var/www/user as described in README.md
This commit also includes https://github.com/Freiheitswolke/docker-grav/tree/fix/volume and some changes to README.md to reflect the changed volumes. The commit will not break the old way with a mount for the whole '/var/www/html' for those who want to upgrade grav via the admin console. (If '/var/www/html' is mounted you need to populate the whole directory yourself after starting the container anyway.)
Building or pulling the container image with the new version of grav is a more proper way to perform upgrades in my opinion.

Closes getgrav#44

Kind regards and thank you for all the great work so far
Simon