### PR TITLE
Draft: Store grav files in GCS using gcsfuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN a2enmod rewrite expires && \
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini \
+    lsb-release \
     unzip \
     libfreetype6-dev \
     libjpeg62-turbo-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+volumes:
+  grav-data:
+    driver: local
+    driver_opts:
+      type: none
+      device: $PWD/grav
+      o: bind
+
+services:
+  grav:
+    build: ./
+    ports:
+      - 8080:80
+    volumes:
+      - grav-data:/var/www/html


### PR DESCRIPTION
Integrate gcsfuse into the standard Grav container deployment. The objective is to get this container to run statelessly in Cloud Run, but store the stateful and persistent files that define the website in a bucket on GCS. The container would mount the GCS bucket as a volume.