### PR TITLE
Draft version of ubi9 image

### DIFF
--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -5,7 +5,8 @@ USER root
 RUN dnf remove --disableplugin subscription-manager --disableplugin product-id -y subscription-manager && \
     dnf install -y cronie && \
     dnf clean all && \
-    chown default:root /var/run && setcap cap_setuid=ep /usr/sbin/crond
+    chown default:root /var/run && setcap "cap_setuid=ep cap_setgid=ep" /usr/sbin/crond && \
+    sed -i 's/\(account     required      pam_unix.so\)/\1 broken_shadow/g' /etc/pam.d/system-auth
 
 # Reset to default application user
 USER default

--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -4,7 +4,8 @@ FROM registry.access.redhat.com/ubi9/php-81
 USER root
 RUN dnf remove --disableplugin subscription-manager --disableplugin product-id -y subscription-manager && \
     dnf install -y cronie && \
-    dnf clean all
+    dnf clean all && \
+    chown default:root /var/run && setcap cap_setuid=ep /usr/sbin/crond
 
 # Reset to default application user
 USER default
@@ -43,6 +44,7 @@ WORKDIR /opt/app-root/src
 
 # Create cron job for Grav maintenance scripts
 RUN (crontab -l; echo "* * * * * cd /opt/app-root/src;/usr/bin/php bin/grav scheduler 1>> /dev/null 2>&1") | crontab -
+COPY --chown=default:root php-pre-start/ ./php-pre-start
 
 # Provide a volume inside image for data persistence
 VOLUME ["/opt/app-root/src"]

--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -1,0 +1,50 @@
+FROM registry.access.redhat.com/ubi9/php-81
+
+# Install dependencies
+USER root
+RUN dnf remove --disableplugin subscription-manager --disableplugin product-id -y subscription-manager && \
+    dnf install -y cronie && \
+    dnf clean all
+
+# Reset to default application user
+USER default
+
+# Define Grav version
+ARG GRAV_VERSION=latest
+
+# Unpack Grav
+WORKDIR /tmp
+RUN curl -o grav-admin.zip -fL --no-progress-meter https://getgrav.org/download/core/grav-admin/${GRAV_VERSION} && \
+    unzip grav-admin.zip && \
+    mv grav-admin/* grav-admin/.[!.]* /opt/app-root/src/ && \
+    rm -rf grav-admin*
+
+# Reset working directory back to s2i default
+WORKDIR /opt/app-root/src
+
+#######
+# Here you can do pre-configuration of the image if needed.
+#######
+# For example, install Grav plugins or themes
+#
+#RUN bin/gpm direct-install -y https://getgrav.org/download/plugins/anchors/1.6.0 && \
+#    bin/gpm direct-install -y https://getgrav.org/download/plugins/external_links/1.6.3
+
+# Or run needed scripts to pre-create things
+#RUN bin/plugin tntsearch index
+
+# Or do customizations via patches
+#RUN --mount=type=bind,source=patches/,target=/tmp/patches \
+#    patch -p1 -d user/plugins/tntsearch < /tmp/patches/tntsearch.patch
+
+# Or just overwrite full files with your own copy
+#COPY --chown=default:root pages/ ./user/pages
+#######
+
+# Create cron job for Grav maintenance scripts
+RUN (crontab -l; echo "* * * * * cd /opt/app-root/src;/usr/bin/php bin/grav scheduler 1>> /dev/null 2>&1") | crontab -
+
+# Provide a volume inside image for data persistence
+VOLUME ["/opt/app-root/src"]
+
+CMD /usr/libexec/s2i/run

--- a/php-pre-start/run-cron.sh
+++ b/php-pre-start/run-cron.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+crond


### PR DESCRIPTION
This image is built using ubi9 base images from RedHat, and at least at some level follows s2i framework.

Pros
* It builds much faster as Apache, PHP and almost all other dependencies are already prebuilt.
* PHP is running as CGI (PHP-FPM) instead of Apache module, which in some cases could be faster.
* Various parameters from [s2i framework](https://github.com/sclorg/s2i-php-container/tree/master/8.1) can be used to customize Apache and PHP configuration. s2i can be used even further to build the image directly from GitHub URL + install Composer dependencies skipping ZIP download all together, though one must check if Grav is ready for that.
* Some configuration options, such as `MaxRequestWorkers` are automatically adjusted depending on the memory allowed during the runtime.
* Supports running Grav with HTTPS without any additional proxies. One just needs to add correct certificates to ./httpd-ssl folder.
* Image is rootless. Apache and PHP-FPM runs as `default` user, though this can be modified if needed by just adding `USER` directive to the Dockerfile.

Cons
* The image is ~20% bigger. If this is a showstopper we could try to use s2i-core base instead of s2i-base and configure Apache ourselves, as current base image includes node.js for some reason. Building from s2i-base would still be faster than previously as Apache/PHP installation in RPM OSes is straight forward.
* Doesn't include yaml PECL module as official RedHat repositories do not have it.

Caveats:
* The image removes subscription-manager so it won't ping RedHat home.
* Default port is now 8080 (8443 for HTTPS).
* Cron still runs as root, so it cannot be killed, if needed, inside rootless image.

TODO:
- [ ] Adjust default PHP settings to where they were in the old image. Most of the defaults are actually already in sync.
- [ ] Disable Apache version exposure for production use.
- [ ] Decide if a volume really should point to Grav web root. Currently I left it as it were. IMHO, it would be better to just persist /user and maybe /logs folders.
- [ ] Adjust documentation.