### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -101,7 +101,8 @@ setup_cron() {
     CRON_JOB="* * * * * cd ${GRAV_HOME} && /usr/local/bin/php bin/grav scheduler 1>> /dev/null 2>&1"
 
     # Add to www-data's crontab if not already present
-    (crontab -u www-data -l 2>/dev/null | grep -v "grav scheduler"; echo "${CRON_JOB}") | crontab -u www-data -
+    CRONTAB=$(crontab -u www-data -l 2>/dev/null | grep -v "grav scheduler"; echo "${CRON_JOB}") 
+    echo "${CRONTAB}" | crontab -u www-data -
 
     log_info "Cron job configured!"
 }


### PR DESCRIPTION
Inconsistent results when piping multiple-command output into crontab - often leading to an empty crontab for www-data. 

Changed setup_cron() to use temporary variable instead of direct-piping.